### PR TITLE
Address TRAC-795.

### DIFF
--- a/includes/upload.tab.inc
+++ b/includes/upload.tab.inc
@@ -45,8 +45,8 @@ function islandora_scholar_modify_form(array $form, array &$form_state, Abstract
   $mods_doc->loadXML($mods_str);
   $mods_xpath = new DOMXPath($mods_doc);
   $mods_xpath->registerNamespace('m', 'http://www.loc.gov/mods/v3');
-  $usage = t('No usage statement');
-  $mods_usages = $mods_xpath->query('//m:mods/m:accessCondition[@type="use and reproduction"]');
+  $usage = t('No usage statement');;
+  $mods_usages = $mods_xpath->query( '//m:mods/m:note[@displayLabel="Copyright holder"]');
   if ($mods_usages->length > 0) {
     $usage = $mods_usages->item(0)->textContent;
   }
@@ -223,7 +223,7 @@ function islandora_scholar_add_usage_and_version_elements_to_mods(AbstractObject
   $xpath->registerNamespace('mods', $namespace);
   // Remove all instances of mods:accessCondition and mods:physicalDescription
   // from every mods:mods element instance.
-  $access_condition_query = '//mods:accessCondition[@type="use and reproduction"]';
+  $access_condition_query = '//mods:note[@displayLabel="Copyright holder"]';
   $physical_description_query = '//mods:physicalDescription[@authority="local"]';
   $results = $xpath->query("{$access_condition_query} | {$physical_description_query}");
   foreach ($results as $result) {
@@ -235,14 +235,13 @@ function islandora_scholar_add_usage_and_version_elements_to_mods(AbstractObject
   if ($results->length == 0) {
     drupal_set_message(t('Could not find MODS element in object @pid is empty. %refuse.', array('@pid' => $object->id, '%refuse' => $refuse_msg)), 'error');
     return;
-  }
+  } 
   $mods_element = $results->item(0);
-  // Add mods:accessCondition to the first mods:mods element.
-  $access_condition_element = $doc->createElementNS($namespace, 'accessCondition');
-  $access_condition_element->setAttribute('type', 'use and reproduction');
-  $access_condition_element->setAttribute('displayLabel', 'Copyright holder');
-  $access_condition_element->nodeValue = $usage;
-  $mods_element->appendChild($access_condition_element);
+  // Add mods:note[@displayLable="Copyright holder"] to the first mods:mods element.
+  $copyright_holder_element = $doc->createElementNS($namespace, 'note');
+  $copyright_holder_element->setAttribute('displayLabel', 'Copyright holder');
+  $copyright_holder_element->nodeValue = $usage;
+  $mods_element->appendChild($copyright_holder_element);
   // Add mods:physicalDescription to the first mods:mods element.
   $physical_description_element = $doc->createElementNS($namespace, 'physicalDescription');
   $physical_description_note = $doc->createElementNS($namespace, 'note');


### PR DESCRIPTION
**JIRA Ticket**: [TRAC-795](https://jira.lib.utk.edu/browse/TRAC-795)

# What does this Pull Request do?

Moves where the concept of who owns rights is held in the MODS record to note[@displayLabel="Copyright holder"]

# What's new?
For some reason, the community puts this concept in a bad place:  under accessCondition[@type="use and reproduction"].  This is wrong.  The concept that their trying to save doesn't really fit neatly anywhere in MODS.  For that reason, we need to just move it to note and jail it with it's own attribute value.

# How should this be tested?

Overwrite the affected files in your vagrant and submit a new ETD.

# Additional Notes:

The place we're storing this is a catch all for sketch data.  If possible, it'd be best serialize this at /name/namePart/role/roleTerm, but there is a lot of planning that needs to be discussed to do this.  This just gets thing in a place where the librarians won't complain.

# Interested parties
@CanOfBees @DonRichards @robert-patrick-waltz @pc37utn @cdeaneGit 
