### PR TITLE
address TRAC-659 and TRAC-767: update embargo sub-module stylesheets …

### DIFF
--- a/modules/islandora_scholar_embargo/xml/xacml_create_embargo_rule.xsl
+++ b/modules/islandora_scholar_embargo/xml/xacml_create_embargo_rule.xsl
@@ -40,15 +40,7 @@
                 </xsl:call-template>
 
                 <Actions>
-                    <Action>
-                        <ActionMatch MatchId="urn:oasis:names:tc:xacml:1.0:function:string-equal">
-                            <AttributeValue DataType="http://www.w3.org/2001/XMLSchema#string">
-                                urn:fedora:names:fedora:2.1:action:id-getDatastreamDissemination
-                            </AttributeValue>
-                            <ActionAttributeDesignator AttributeId="urn:fedora:names:fedora:2.1:action:id"
-                                                       DataType="http://www.w3.org/2001/XMLSchema#string"/>
-                        </ActionMatch>
-                    </Action>
+                    <AnyAction/>
                 </Actions>
             </Target>
             <Condition FunctionId="urn:oasis:names:tc:xacml:1.0:function:not">
@@ -69,8 +61,7 @@
                         <SubjectAttributeDesignator DataType="http://www.w3.org/2001/XMLSchema#string"
                                                     MustBePresent="false" AttributeId="fedoraRole"/>
                         <Apply FunctionId="urn:oasis:names:tc:xacml:1.0:function:string-bag">
-                            <AttributeValue DataType="http://www.w3.org/2001/XMLSchema#string">administrator
-                            </AttributeValue>
+                            <AttributeValue DataType="http://www.w3.org/2001/XMLSchema#string">administrator</AttributeValue>
                         </Apply>
                     </Apply>
                 </Apply>

--- a/modules/islandora_scholar_embargo/xml/xacml_create_embargo_rule.xsl
+++ b/modules/islandora_scholar_embargo/xml/xacml_create_embargo_rule.xsl
@@ -62,6 +62,7 @@
                                                     MustBePresent="false" AttributeId="fedoraRole"/>
                         <Apply FunctionId="urn:oasis:names:tc:xacml:1.0:function:string-bag">
                             <AttributeValue DataType="http://www.w3.org/2001/XMLSchema#string">administrator</AttributeValue>
+                            <AttributeValue DataType="http://www.w3.org/2001/XMLSchema#string">thesis_manager_role</AttributeValue>
                         </Apply>
                     </Apply>
                 </Apply>


### PR DESCRIPTION
…Actions.

**JIRA Ticket**: [TRAC-659](https://jira.lib.utk.edu/browse/TRAC-659) and [TRAC-767](https://jira.lib.utk.edu/browse/TRAC-767)

# What does this Pull Request do?
This PR modifies the XACML Policy datastream -- blocking all actions unless the user falls inside of a list of users.

# What's new?
Replaced id-getDatastreamDissemination with AnyAction.

# How should this be tested?
* clone and replace the stylesheet in your VM. embargo an object, then try to access it. 
* alternately, in your VM, comment and update the section of the stylesheet to reflect these changes and then embargo/access an object.

# Interested parties
@robert-patrick-waltz 
