### PR TITLE
address TRAC-835 (and TRAC-1088)

### DIFF
--- a/includes/utilities.inc
+++ b/includes/utilities.inc
@@ -58,6 +58,7 @@ function islandora_scholar_get_view(AbstractObject $object) {
           '#weight' => $i++,
       ),
       'supplemental_download_8' => array(
+          '#weight' => $i++,
       ),
       'supplemental_download_9' => array(
           '#weight' => $i++,


### PR DESCRIPTION
**JIRA Ticket**: [TRAC-835](https://jira.lib.utk.edu/browse/TRAC-835) and [TRAC-1088](https://jira.lib.utk.edu/browse/TRAC-1088)

# What does this Pull Request do?
Updates `supplemental_download_8` to include a \#weight.

# What's new?

# How should this be tested?
* make sure you have a recent vagrant VM
* make sure you have an ETD with at least 9 supplemental files
* verify that you are seeing the issue mentioned in TRAC-835/TRAC-1088
* include the `islandora_scholar/includes/utilities.inc` file in your vagrant VM
* refresh the item-level display to verify that suppl_8 download is in the correct place on the page

# Interested parties
@utkdigitalinitiatives/digital-initiatives-developers  
